### PR TITLE
allow nil values in filters

### DIFF
--- a/lib/philtre/filter.rb
+++ b/lib/philtre/filter.rb
@@ -72,7 +72,7 @@ module Philtre
     # the filter expression.
     def valued_parameters
       filter_parameters.select do |key,value|
-        key.to_sym != :order && (value.is_a?(Array) || !value.blank?)
+        key.to_sym != :order && (value.is_a?(Array) || value != '' || !value.blank?)
       end
     end
 

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -348,10 +348,6 @@ describe Philtre::Filter do
       described_class.new( address: '' ).expressions.should be_empty
     end
 
-    it 'ignores nil value' do
-      described_class.new( address: nil ).expressions.should be_empty
-    end
-
     it 'accepts []' do
       expressions = described_class.new( flavour: [] ).expressions
       expressions.size.should == 1
@@ -414,12 +410,6 @@ describe Philtre::Filter do
 
     it 'excludes blank values' do
       filter.filter_parameters[:name] = ''
-      sql = filter.apply(@dataset).sql
-      sql.should =~ /select \* from planks where \(title = '\w+'\)$/i
-    end
-
-    it 'excludes nil values' do
-      filter.filter_parameters[:name] = nil
       sql = filter.apply(@dataset).sql
       sql.should =~ /select \* from planks where \(title = '\w+'\)$/i
     end


### PR DESCRIPTION
Nils are valid values for equality filters when searching for records for which foreign keys are not set. 
